### PR TITLE
fix: add www-authenticate challenge headers

### DIFF
--- a/service.go
+++ b/service.go
@@ -60,6 +60,12 @@ func proxy(c *gin.Context) {
 		req.URL.Host = remote.Host
 		req.URL.Path = c.Param("proxyPath")
 	}
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if resp.StatusCode == http.StatusUnauthorized {
+			resp.Header.Set("WWW-Authenticate", "Basic realm=\"basicToOauth\"")
+		}
+		return nil
+	}
 	proxy.ServeHTTP(c.Writer, c.Request)
 }
 


### PR DESCRIPTION
This change is required due to a recent change on Microsoft's side. When the upstream returns a 401 Unauthorized, the proxy injects a custom WWW-Authenticate challenge before sending the response back to the client. Most applications require this before attempting basic auth.

This fixes #10 